### PR TITLE
Check if "service" function exists

### DIFF
--- a/src/Bundle/Resources/config/services.php
+++ b/src/Bundle/Resources/config/services.php
@@ -8,8 +8,23 @@ use PrismaMedia\Metrics\Bundle\Controller\MetricsController;
 use PrismaMedia\Metrics\Bundle\PrismaMediaMetricsBundle;
 use PrismaMedia\Metrics\MetricAggregator;
 use PrismaMedia\Metrics\MetricRenderer;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use function function_exists;
+use function sprintf;
 
 return function (ContainerConfigurator $configurator) {
+
+    $functionRef = sprintf('%s\ref', __NAMESPACE__);
+    $functionService = sprintf('%s\service', __NAMESPACE__);
+
+    $function = function_exists($functionService) ? $functionService : $functionRef;
+
+    if (!function_exists($function)) {
+        throw new LogicException(
+            sprintf('Function "%s" is missing and or not supported by the used Symfony version.', $function)
+        );
+    }
+
     $configurator->services()
         ->set(MetricAggregator::class)
             ->args([tagged_iterator(PrismaMediaMetricsBundle::TAG_METRIC)])
@@ -17,7 +32,7 @@ return function (ContainerConfigurator $configurator) {
         ->set(MetricRenderer::class)
 
         ->set(MetricsController::class)
-            ->args([service(MetricAggregator::class), service(MetricRenderer::class)])
+            ->args([$function(MetricAggregator::class), $function(MetricRenderer::class)])
             ->tag('controller.service_arguments')
     ;
 };

--- a/src/MetricRenderer.php
+++ b/src/MetricRenderer.php
@@ -17,6 +17,6 @@ class MetricRenderer
             }, array_keys($metric->getLabels()), $metric->getLabels())));
         }
 
-        return sprintf("%s%s %s\n", $metric->getName(), $labels, $metric->getValue());
+        return sprintf("%s%s %s \n", $metric->getName(), $labels, $metric->getValue());
     }
 }

--- a/tests/Bundle/FunctionalTest.php
+++ b/tests/Bundle/FunctionalTest.php
@@ -22,9 +22,9 @@ class FunctionalTest extends WebTestCase
         $this->assertResponseIsSuccessful();
 
         $expected =
-            "article_total{brand=\"Capital\"} 42\n".
-            "article_total{brand=\"Femme Actuelle\"} 876\n".
-            "article_total{brand=\"Télé-Loisirs\"} 381\n";
+            "article_total{brand=\"Capital\"} 42 \n".
+            "article_total{brand=\"Femme Actuelle\"} 876 \n".
+            "article_total{brand=\"Télé-Loisirs\"} 381 \n";
         $this->assertSame($expected, $content);
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());


### PR DESCRIPTION
The package claims to be compatible with Symfony 4.4, unfortunately the package uses the `service` function, which is supposed to replace the `ref` function in the `ContainerConfigurator` as of Symfony 5.1.
This PR is intended to restore compatibility with Symfony 4.4.

Closes #15